### PR TITLE
Exposed LOS check to API

### DIFF
--- a/src/doom/api.c
+++ b/src/doom/api.c
@@ -282,6 +282,33 @@ api_response_t API_RouteRequest(api_request_t req)
        
         return API_CreateErrorResponse(405, "Method not allowed");
     }
+
+    else if (strcmp(path, "api/world/movetest") == 0) {
+        if (strcmp(method, "GET") == 0)
+        {
+            printf(req.url.query);
+           
+            int id;
+            float x;
+            float y;
+            struct yuarel_param params[3];
+            int p = yuarel_parse_query(req.url.query, '&', params, 3);
+            while (p-- > 0) {
+                if (strcmp("id", params[p].key) == 0) {
+                    id = atoi(params[p].val); 
+                }
+                if (strcmp("x", params[p].key) == 0) {
+                    x = atoi(params[p].val);
+                }
+                if (strcmp("y", params[p].key) == 0) {
+                    y = atoi(params[p].val);
+                }
+            }
+            return API_GetCheckTraverse(id,x,y);
+        }
+        return API_CreateErrorResponse(405, "Method not allowed");
+    }
+
     else if (strcmp(path, "api/world/doors") == 0) {
         if (strcmp(method, "GET") == 0)
         {

--- a/src/doom/api.c
+++ b/src/doom/api.c
@@ -268,6 +268,20 @@ api_response_t API_RouteRequest(api_request_t req)
         }
         return API_CreateErrorResponse(405, "Method not allowed");
     }
+    else if (strstr(path, "api/world/los/") != NULL) {
+        int id;
+        int id2;
+       
+
+        sscanf(path, "api/world/los/%d/%d", &id,&id2);
+      
+        if (strcmp(method, "GET") == 0)
+        {
+            return API_GetLineOfSightToObject(id,id2);
+        }
+       
+        return API_CreateErrorResponse(405, "Method not allowed");
+    }
     else if (strcmp(path, "api/world/doors") == 0) {
         if (strcmp(method, "GET") == 0)
         {

--- a/src/doom/api_object_controller.c
+++ b/src/doom/api_object_controller.c
@@ -239,3 +239,28 @@ api_response_t API_GetLineOfSightToObject(int id, int id2)
     api_response_t resp = {200, root};
     return resp;
 }
+
+//API_GetCheckMove
+api_response_t API_GetCheckTraverse(int id, float x, float y)
+{
+    
+    mobj_t *obj = FindObjectById(id);
+   
+    if (!obj)
+    {
+        printf("obj is null\n");
+        return API_CreateErrorResponse(404, "object not found");
+    }
+
+    printf("API_GetCheckTraverse attempt for: %d:%d to %d:%d \n",obj->x,obj->y,API_FloatToFixed(x),API_FloatToFixed(y));
+    boolean result = P_PathTraverse(obj->x, obj->y,API_FloatToFixed(x),API_FloatToFixed(y), PT_ADDLINES,PTR_AimTraverse);
+    
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddNumberToObject(root, "id", id);
+    cJSON_AddNumberToObject(root, "x", x);
+    cJSON_AddNumberToObject(root, "y", y);
+    cJSON_AddBoolToObject(root,"result", result);
+
+    api_response_t resp = {200, root};
+    return resp;
+}

--- a/src/doom/api_object_controller.c
+++ b/src/doom/api_object_controller.c
@@ -197,6 +197,10 @@ api_response_t API_DeleteObject(int id)
     return resp;
 }
 
+
+
+
+
 api_response_t API_GetObject(int id)
 {
     mobj_t *obj = FindObjectById(id);
@@ -205,6 +209,33 @@ api_response_t API_GetObject(int id)
         return API_CreateErrorResponse(404, "object not found");
     }
     cJSON* root = DescribeMObj(obj);
+    api_response_t resp = {200, root};
+    return resp;
+}
+
+api_response_t API_GetLineOfSightToObject(int id, int id2)
+{
+    mobj_t *obj = FindObjectById(id);
+    mobj_t *obj2 = FindObjectById(id2);
+
+    if (!obj || !obj2)
+    {
+        printf("obj is null\n");
+        return API_CreateErrorResponse(404, "object not found");
+    }
+
+    mobjtype_t typeOne = obj->type;
+    mobjtype_t typeTwo = obj2->type;
+    printf("LOS check attempt for MObjs: %d:%d , %d:%d \n",id,typeOne,id2,typeTwo);
+
+    boolean los = P_CheckSight (obj, obj2);  
+    printf("LOS Check Result: %d \n", los);
+
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddNumberToObject(root, "id", obj->id);
+    cJSON_AddNumberToObject(root, "id2", obj2->id);
+    cJSON_AddBoolToObject(root,"los", los);
+    
     api_response_t resp = {200, root};
     return resp;
 }

--- a/src/doom/api_object_controller.h
+++ b/src/doom/api_object_controller.h
@@ -6,3 +6,4 @@ api_response_t API_PatchObject(int id, cJSON *req);
 api_response_t API_DeleteObject(int id);
 api_response_t API_GetObject(int id);
 api_response_t API_GetLineOfSightToObject(int id, int id2);
+api_response_t API_GetCheckTraverse(int id, float x, float y);

--- a/src/doom/api_object_controller.h
+++ b/src/doom/api_object_controller.h
@@ -5,3 +5,4 @@ api_response_t API_GetObjects(int max_distance);
 api_response_t API_PatchObject(int id, cJSON *req);
 api_response_t API_DeleteObject(int id);
 api_response_t API_GetObject(int id);
+api_response_t API_GetLineOfSightToObject(int id, int id2);

--- a/src/doom/p_local.h
+++ b/src/doom/p_local.h
@@ -190,7 +190,7 @@ P_PathTraverse
   fixed_t	y2,
   int		flags,
   boolean	(*trav) (intercept_t *));
-
+boolean PTR_AimTraverse (intercept_t* in);
 void P_UnsetThingPosition (mobj_t* thing);
 void P_SetThingPosition (mobj_t* thing);
 


### PR DESCRIPTION
EDIT: Forked Thomas' repo and added a couple of new examples covering these APIs -
 https://github.com/NickMcCrea/restful-doom-players




Poked around the code and found some physics methods that will be useful. Exposed a line of sight check to the API - accepts two mob IDs, and performs a visibility check between them that returns true if there is no obstructing geometry. Doesn't take account of the facing of the entities (so it will return true if you test for a monster behind you).

URL is api/world/los/id1/id2    - which I'm sure breaks some REST API rules but I take the view that we're hacking a restful API into a 20 year old C program so what the hell.

Have also now exposed the PathTraversal API, which is basically a way to ray cast against geometry. API is /world/movetest?id=1&x=10&y=20.

A line will be drawn from the position of the mob of ID, to X:Y, and returns true if unobstructed, false otherwise. 

